### PR TITLE
add github codespell workflow

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,18 @@
+name: Codespell
+on: [pull_request]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          # only show the typo detected but don't make workflow to fail
+          only_warn: 1
+          skip: "*.ts"
+          # word to exclude must be always lowercase as must be same of the codespell dictionary
+          ignore_words_list: ba


### PR DESCRIPTION
This help to detect spelling errors and show them in pull requests. only_warn for don't fails check but only show errors and make "optional" for contributors solve them.
Skip translation files that can give many false errors. Ignore words that are variable or code and are not real spelling error, is possible other exclusions are needed.